### PR TITLE
Upgrade SSL 3.0 / TLS 1.0 to TLS 1.2

### DIFF
--- a/src/Portability/Rocket.Chat.Net.Portability.Android/Websockets/PortableWebSocket.cs
+++ b/src/Portability/Rocket.Chat.Net.Portability.Android/Websockets/PortableWebSocket.cs
@@ -12,7 +12,14 @@
 
         public PortableWebSocket(string url) : base(url)
         {
-            _socket = new WebSocket(url);
+            if (url.StartsWith("wss"))
+            {
+                _socket = new WebSocket(url, sslProtocols: SslProtocols.Tls12);
+            }
+            else
+            {
+                _socket = new WebSocket(url);
+            }
         }
 
         public override event EventHandler<PortableMessageReceivedEventArgs> MessageReceived

--- a/src/Portability/Rocket.Chat.Net.Portability.IOS/Websockets/PortableWebSocket.cs
+++ b/src/Portability/Rocket.Chat.Net.Portability.IOS/Websockets/PortableWebSocket.cs
@@ -12,7 +12,14 @@
 
         public PortableWebSocket(string url) : base(url)
         {
-            _socket = new WebSocket(url);
+            if (url.StartsWith("wss"))
+            {
+                _socket = new WebSocket(url, sslProtocols: SslProtocols.Tls12);
+            }
+            else
+            {
+                _socket = new WebSocket(url);
+            }
         }
 
         public override event EventHandler<PortableMessageReceivedEventArgs> MessageReceived

--- a/src/Portability/Rocket.Chat.Net.Portability.Net45/Websockets/PortableWebSocket.cs
+++ b/src/Portability/Rocket.Chat.Net.Portability.Net45/Websockets/PortableWebSocket.cs
@@ -12,7 +12,14 @@
 
         public PortableWebSocket(string url) : base(url)
         {
-            _socket = new WebSocket(url);
+            if (url.StartsWith("wss"))
+            {
+                _socket = new WebSocket(url, sslProtocols: SslProtocols.Tls12);
+            }
+            else
+            {
+                _socket = new WebSocket(url);
+            }
         }
 
         public override event EventHandler<PortableMessageReceivedEventArgs> MessageReceived


### PR DESCRIPTION
By default, WebSocket4Net will attempt to use SSL 3.0 or TLS 1.0 for secure connections. Since most (if not all) modern web servers support at least TLS 1.2 out of the box, this change will ensure the library can correctly establish a secure connection with these web servers, without sacrificing security.

This commit has been checked against an internal Rocket.Chat server, running a NGINX 1.14.0 reverse proxy with both TLS 1.3 and TLS 1.2 enabled, utilizing EECDH+AESGCM and EDH+AESGCM ciphers.